### PR TITLE
feat(timetable): add minute-based session projection

### DIFF
--- a/src/functions/timetable_projection.ts
+++ b/src/functions/timetable_projection.ts
@@ -1,4 +1,9 @@
-import { Course, courseToEndIndex, courseToStartIndex } from "./general";
+import {
+  Course,
+  courseToEndIndex,
+  courseToStartIndex,
+  courseToTime,
+} from "./general";
 
 export const TIMELINE_START_MINUTE = 7 * 60;
 export const TIMELINE_END_MINUTE = 22 * 60;
@@ -31,40 +36,22 @@ const weekdayMap: Record<string, number> = {
   六: 6,
 };
 
-const numericStarts = [
-  "07:10", "08:10", "09:10", "10:10", "11:10",
-  "12:10", "13:10", "14:10", "15:10", "16:10",
-  "17:10", "18:10", "19:10", "20:10", "21:10",
-];
-const letterStarts = [
-  "07:15", "08:45", "10:15", "11:45", "13:15",
-  "14:45", "16:15", "17:45", "19:15", "20:45",
-];
-
 function timeToMinute(time: string): number {
   const [hour, minute] = time.split(":").map(Number);
   return hour * 60 + minute;
 }
 
-export const PERIOD_DEFINITIONS: Record<string, PeriodDefinition> = {};
+export const PERIOD_DEFINITIONS: Record<string, PeriodDefinition> =
+  {};
 
-numericStarts.forEach((time, index) => {
+Object.entries(courseToTime).forEach(([code, time]) => {
   const startMinute = timeToMinute(time);
-  const code = String(index + 1);
+  const duration = /^\d+$/.test(code) ? 50 : 75;
+
   PERIOD_DEFINITIONS[code] = {
     code,
     startMinute,
-    endMinute: startMinute + 50,
-  };
-});
-
-letterStarts.forEach((time, index) => {
-  const startMinute = timeToMinute(time);
-  const code = String.fromCharCode("A".charCodeAt(0) + index);
-  PERIOD_DEFINITIONS[code] = {
-    code,
-    startMinute,
-    endMinute: startMinute + 75,
+    endMinute: startMinute + duration,
   };
 });
 
@@ -86,7 +73,9 @@ function parseCodes(value: string): string[] {
   const normalized = value.trim().toUpperCase();
   if (!normalized) return [];
 
-  const rangeParts = normalized.split(/[~-]/).map((part) => part.trim());
+  const rangeParts = normalized
+    .split(/[~-]/)
+    .map((part) => part.trim());
   if (rangeParts.length === 2) {
     return expandRange(rangeParts[0], rangeParts[1]);
   }
@@ -99,7 +88,9 @@ function parseCodes(value: string): string[] {
 
 function sessionsFromCourse(course: Course): TimetableSession[] {
   const rawTime = course.getStartTime() || "";
-  const segments = [...rawTime.matchAll(/([一二三四五六])([^\s一二三四五六]+)/g)];
+  const segments = [
+    ...rawTime.matchAll(/([一二三四五六])([^\s一二三四五六]+)/g),
+  ];
   const sessions: TimetableSession[] = [];
 
   for (const segment of segments) {
@@ -116,7 +107,9 @@ function sessionsFromCourse(course: Course): TimetableSession[] {
       const first = group[0];
       const last = group[group.length - 1];
       const periodLabel =
-        group.length === 1 ? first.code : `${first.code}–${last.code}`;
+        group.length === 1
+          ? first.code
+          : `${first.code}–${last.code}`;
       sessions.push({
         key: `${course.getUuid()}-${weekday}-${first.startMinute}`,
         weekday,
@@ -133,7 +126,10 @@ function sessionsFromCourse(course: Course): TimetableSession[] {
 
     for (const definition of definitions) {
       const previous = group[group.length - 1];
-      if (previous && definition.startMinute - previous.endMinute > 15) {
+      if (
+        previous &&
+        definition.startMinute - previous.endMinute > 15
+      ) {
         flush();
       }
       group.push(definition);
@@ -144,13 +140,18 @@ function sessionsFromCourse(course: Course): TimetableSession[] {
   return sessions;
 }
 
-function inferFallbackPeriod(startIndex: number, endIndex: number, startTime: string) {
+function inferFallbackPeriod(
+  startIndex: number,
+  endIndex: number,
+  startTime: string,
+) {
   const candidates = Object.values(PERIOD_DEFINITIONS).filter(
     (period) => courseToStartIndex[period.code] === startIndex,
   );
-  const preferred = candidates.find(
-    (period) => `${String(Math.floor(period.startMinute / 60)).padStart(2, "0")}:${String(period.startMinute % 60).padStart(2, "0")}` === startTime,
-  ) ?? candidates[0];
+  const preferred =
+    candidates.find(
+      (period) => formatMinute(period.startMinute) === startTime,
+    ) ?? candidates[0];
 
   if (!preferred) {
     return {
@@ -160,7 +161,9 @@ function inferFallbackPeriod(startIndex: number, endIndex: number, startTime: st
     };
   }
 
-  const sameSeries = /^\d+$/.test(preferred.code) ? /^\d+$/ : /^[A-J]$/;
+  const sameSeries = /^\d+$/.test(preferred.code)
+    ? /^\d+$/
+    : /^[A-J]$/;
   const matching = Object.values(PERIOD_DEFINITIONS)
     .filter(
       (period) =>
@@ -175,11 +178,16 @@ function inferFallbackPeriod(startIndex: number, endIndex: number, startTime: st
     startMinute: preferred.startMinute,
     endMinute: last.endMinute,
     periodLabel:
-      matching.length > 1 ? `${preferred.code}–${last.code}` : preferred.code,
+      matching.length > 1
+        ? `${preferred.code}–${last.code}`
+        : preferred.code,
   };
 }
 
-function sessionsFromMatrix(matrix: Course[][], knownKeys: Set<string>) {
+function sessionsFromMatrix(
+  matrix: Course[][],
+  knownKeys: Set<string>,
+) {
   const sessions: TimetableSession[] = [];
   for (let weekday = 1; weekday <= 6; weekday++) {
     const column = weekday + 2;
@@ -226,7 +234,10 @@ function assignOverlapColumns(sessions: TimetableSession[]) {
   for (let weekday = 1; weekday <= 6; weekday++) {
     const daySessions = sessions
       .filter((session) => session.weekday === weekday)
-      .sort((a, b) => a.startMinute - b.startMinute || a.endMinute - b.endMinute);
+      .sort(
+        (a, b) =>
+          a.startMinute - b.startMinute || a.endMinute - b.endMinute,
+      );
     let cluster: TimetableSession[] = [];
     let clusterEnd = -1;
 
@@ -234,17 +245,21 @@ function assignOverlapColumns(sessions: TimetableSession[]) {
       if (!cluster.length) return;
       const laneEnds: number[] = [];
       for (const session of cluster) {
-        let lane = laneEnds.findIndex((end) => end <= session.startMinute);
+        let lane = laneEnds.findIndex(
+          (end) => end <= session.startMinute,
+        );
         if (lane < 0) lane = laneEnds.length;
         laneEnds[lane] = session.endMinute;
         session.overlapIndex = lane;
       }
-      for (const session of cluster) session.overlapCount = laneEnds.length;
+      for (const session of cluster)
+        session.overlapCount = laneEnds.length;
       cluster = [];
     };
 
     for (const session of daySessions) {
-      if (cluster.length && session.startMinute >= clusterEnd) flush();
+      if (cluster.length && session.startMinute >= clusterEnd)
+        flush();
       cluster.push(session);
       clusterEnd = Math.max(clusterEnd, session.endMinute);
     }
@@ -272,7 +287,9 @@ export function projectTimetableSessions(
 }
 
 export function minuteToTimelineOffset(minute: number): number {
-  return ((minute - TIMELINE_START_MINUTE) * TIMELINE_HOUR_HEIGHT) / 60;
+  return (
+    ((minute - TIMELINE_START_MINUTE) * TIMELINE_HOUR_HEIGHT) / 60
+  );
 }
 
 export function formatMinute(minute: number): string {

--- a/src/functions/timetable_projection.ts
+++ b/src/functions/timetable_projection.ts
@@ -1,0 +1,280 @@
+import { Course, courseToEndIndex, courseToStartIndex } from "./general";
+
+export const TIMELINE_START_MINUTE = 7 * 60;
+export const TIMELINE_END_MINUTE = 22 * 60;
+export const TIMELINE_HOUR_HEIGHT = 64;
+
+export interface PeriodDefinition {
+  code: string;
+  startMinute: number;
+  endMinute: number;
+}
+
+export interface TimetableSession {
+  key: string;
+  weekday: number;
+  startMinute: number;
+  endMinute: number;
+  periodLabel: string;
+  courseUuid: string;
+  course: Course;
+  overlapIndex: number;
+  overlapCount: number;
+}
+
+const weekdayMap: Record<string, number> = {
+  一: 1,
+  二: 2,
+  三: 3,
+  四: 4,
+  五: 5,
+  六: 6,
+};
+
+const numericStarts = [
+  "07:10", "08:10", "09:10", "10:10", "11:10",
+  "12:10", "13:10", "14:10", "15:10", "16:10",
+  "17:10", "18:10", "19:10", "20:10", "21:10",
+];
+const letterStarts = [
+  "07:15", "08:45", "10:15", "11:45", "13:15",
+  "14:45", "16:15", "17:45", "19:15", "20:45",
+];
+
+function timeToMinute(time: string): number {
+  const [hour, minute] = time.split(":").map(Number);
+  return hour * 60 + minute;
+}
+
+export const PERIOD_DEFINITIONS: Record<string, PeriodDefinition> = {};
+
+numericStarts.forEach((time, index) => {
+  const startMinute = timeToMinute(time);
+  const code = String(index + 1);
+  PERIOD_DEFINITIONS[code] = {
+    code,
+    startMinute,
+    endMinute: startMinute + 50,
+  };
+});
+
+letterStarts.forEach((time, index) => {
+  const startMinute = timeToMinute(time);
+  const code = String.fromCharCode("A".charCodeAt(0) + index);
+  PERIOD_DEFINITIONS[code] = {
+    code,
+    startMinute,
+    endMinute: startMinute + 75,
+  };
+});
+
+function expandRange(start: string, end: string): string[] {
+  const codes = Object.keys(PERIOD_DEFINITIONS);
+  const startIndex = codes.indexOf(start);
+  const endIndex = codes.indexOf(end);
+  const sameSeries =
+    (/^\d+$/.test(start) && /^\d+$/.test(end)) ||
+    (/^[A-J]$/.test(start) && /^[A-J]$/.test(end));
+
+  if (!sameSeries || startIndex < 0 || endIndex < startIndex) {
+    return [start];
+  }
+  return codes.slice(startIndex, endIndex + 1);
+}
+
+function parseCodes(value: string): string[] {
+  const normalized = value.trim().toUpperCase();
+  if (!normalized) return [];
+
+  const rangeParts = normalized.split(/[~-]/).map((part) => part.trim());
+  if (rangeParts.length === 2) {
+    return expandRange(rangeParts[0], rangeParts[1]);
+  }
+
+  return normalized
+    .split(",")
+    .map((code) => code.trim())
+    .filter((code) => Boolean(PERIOD_DEFINITIONS[code]));
+}
+
+function sessionsFromCourse(course: Course): TimetableSession[] {
+  const rawTime = course.getStartTime() || "";
+  const segments = [...rawTime.matchAll(/([一二三四五六])([^\s一二三四五六]+)/g)];
+  const sessions: TimetableSession[] = [];
+
+  for (const segment of segments) {
+    const weekday = weekdayMap[segment[1]];
+    const codes = parseCodes(segment[2]);
+    const definitions = codes
+      .map((code) => PERIOD_DEFINITIONS[code])
+      .filter(Boolean)
+      .sort((a, b) => a.startMinute - b.startMinute);
+
+    let group: PeriodDefinition[] = [];
+    const flush = () => {
+      if (!group.length) return;
+      const first = group[0];
+      const last = group[group.length - 1];
+      const periodLabel =
+        group.length === 1 ? first.code : `${first.code}–${last.code}`;
+      sessions.push({
+        key: `${course.getUuid()}-${weekday}-${first.startMinute}`,
+        weekday,
+        startMinute: first.startMinute,
+        endMinute: last.endMinute,
+        periodLabel,
+        courseUuid: course.getUuid(),
+        course,
+        overlapIndex: 0,
+        overlapCount: 1,
+      });
+      group = [];
+    };
+
+    for (const definition of definitions) {
+      const previous = group[group.length - 1];
+      if (previous && definition.startMinute - previous.endMinute > 15) {
+        flush();
+      }
+      group.push(definition);
+    }
+    flush();
+  }
+
+  return sessions;
+}
+
+function inferFallbackPeriod(startIndex: number, endIndex: number, startTime: string) {
+  const candidates = Object.values(PERIOD_DEFINITIONS).filter(
+    (period) => courseToStartIndex[period.code] === startIndex,
+  );
+  const preferred = candidates.find(
+    (period) => `${String(Math.floor(period.startMinute / 60)).padStart(2, "0")}:${String(period.startMinute % 60).padStart(2, "0")}` === startTime,
+  ) ?? candidates[0];
+
+  if (!preferred) {
+    return {
+      startMinute: TIMELINE_START_MINUTE + startIndex * 30,
+      endMinute: TIMELINE_START_MINUTE + endIndex * 30,
+      periodLabel: "",
+    };
+  }
+
+  const sameSeries = /^\d+$/.test(preferred.code) ? /^\d+$/ : /^[A-J]$/;
+  const matching = Object.values(PERIOD_DEFINITIONS)
+    .filter(
+      (period) =>
+        sameSeries.test(period.code) &&
+        courseToStartIndex[period.code] >= startIndex &&
+        courseToEndIndex[period.code] <= endIndex,
+    )
+    .sort((a, b) => a.startMinute - b.startMinute);
+  const last = matching[matching.length - 1] ?? preferred;
+
+  return {
+    startMinute: preferred.startMinute,
+    endMinute: last.endMinute,
+    periodLabel:
+      matching.length > 1 ? `${preferred.code}–${last.code}` : preferred.code,
+  };
+}
+
+function sessionsFromMatrix(matrix: Course[][], knownKeys: Set<string>) {
+  const sessions: TimetableSession[] = [];
+  for (let weekday = 1; weekday <= 6; weekday++) {
+    const column = weekday + 2;
+    let row = 0;
+    while (row < matrix.length) {
+      const course = matrix[row]?.[column];
+      if (!course?.getIsCourse()) {
+        row++;
+        continue;
+      }
+
+      const uuid = course.getUuid();
+      const startIndex = row;
+      while (
+        row < matrix.length &&
+        matrix[row]?.[column]?.getIsCourse() &&
+        matrix[row][column].getUuid() === uuid
+      ) {
+        row++;
+      }
+      const endIndex = row;
+      const inferred = inferFallbackPeriod(
+        startIndex,
+        endIndex,
+        course.getStartTime(),
+      );
+      const key = `${uuid}-${weekday}-${inferred.startMinute}`;
+      if (knownKeys.has(key)) continue;
+      sessions.push({
+        key,
+        weekday,
+        ...inferred,
+        courseUuid: uuid,
+        course,
+        overlapIndex: 0,
+        overlapCount: 1,
+      });
+    }
+  }
+  return sessions;
+}
+
+function assignOverlapColumns(sessions: TimetableSession[]) {
+  for (let weekday = 1; weekday <= 6; weekday++) {
+    const daySessions = sessions
+      .filter((session) => session.weekday === weekday)
+      .sort((a, b) => a.startMinute - b.startMinute || a.endMinute - b.endMinute);
+    let cluster: TimetableSession[] = [];
+    let clusterEnd = -1;
+
+    const flush = () => {
+      if (!cluster.length) return;
+      const laneEnds: number[] = [];
+      for (const session of cluster) {
+        let lane = laneEnds.findIndex((end) => end <= session.startMinute);
+        if (lane < 0) lane = laneEnds.length;
+        laneEnds[lane] = session.endMinute;
+        session.overlapIndex = lane;
+      }
+      for (const session of cluster) session.overlapCount = laneEnds.length;
+      cluster = [];
+    };
+
+    for (const session of daySessions) {
+      if (cluster.length && session.startMinute >= clusterEnd) flush();
+      cluster.push(session);
+      clusterEnd = Math.max(clusterEnd, session.endMinute);
+    }
+    flush();
+  }
+}
+
+export function projectTimetableSessions(
+  courseList: Course[],
+  matrix: Course[][],
+): TimetableSession[] {
+  const projected = courseList.flatMap(sessionsFromCourse);
+  const knownKeys = new Set(projected.map((session) => session.key));
+  projected.push(...sessionsFromMatrix(matrix, knownKeys));
+
+  const visible = projected.filter(
+    (session) =>
+      session.weekday >= 1 &&
+      session.weekday <= 6 &&
+      session.endMinute > TIMELINE_START_MINUTE &&
+      session.startMinute < TIMELINE_END_MINUTE,
+  );
+  assignOverlapColumns(visible);
+  return visible;
+}
+
+export function minuteToTimelineOffset(minute: number): number {
+  return ((minute - TIMELINE_START_MINUTE) * TIMELINE_HOUR_HEIGHT) / 60;
+}
+
+export function formatMinute(minute: number): string {
+  return `${String(Math.floor(minute / 60)).padStart(2, "0")}:${String(minute % 60).padStart(2, "0")}`;
+}


### PR DESCRIPTION
## 說明

本 PR 已從原本複雜的 #6 拆分出來，專注於 timetable 的 minute-based session projection。

主要新增了一層資料投影的方法，將原本依賴節次 index 的課程時間資料，轉換為可供後續 timeline renderer 使用的時間資訊。

後續會有 timeline renderer 依賴本 PR 內容，因此想先請 Reviewer 們協助確認一下在架構上與命名上是否合適，若有其他想法與建議，也歡迎提出！


## 修改內容

- 新增 `timetable_projection.ts`
- 將課程節次轉換為實際 minute-based time range
- 提供 timeline 起點、終點的時間常數
- 提供 timeline 垂直高度計算所需資訊
- 處理課程 overlap / lane projection
- 保留現有資料結構，沒有對 UI 進行直接的修改。

## 驗證

```text
npm run build
✓ built
```

